### PR TITLE
refactoring in preparation for imagestream restore action

### DIFF
--- a/velero-plugins/build/restore.go
+++ b/velero-plugins/build/restore.go
@@ -5,18 +5,17 @@ import (
 	"fmt"
 	"strings"
 
-	v1 "github.com/heptio/velero/pkg/apis/velero/v1"
+	"github.com/fusor/ocp-velero-plugin/velero-plugins/clients"
+	v1 "github.com/heptio/velero/pkg/apis/ark/v1"
 	"github.com/heptio/velero/pkg/restore"
 	buildv1API "github.com/openshift/api/build/v1"
 	"github.com/sirupsen/logrus"
 	corev1API "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
 )
 
-// MyRestorePlugin is a restore item action plugin for Velero
+// RestorePlugin is a restore item action plugin for Velero
 type RestorePlugin struct {
 	Log logrus.FieldLogger
 }
@@ -28,6 +27,7 @@ func (p *RestorePlugin) AppliesTo() (restore.ResourceSelector, error) {
 	}, nil
 }
 
+// Execute action for the restore plugin for the build resource
 func (p *RestorePlugin) Execute(item runtime.Unstructured, restore *v1.Restore) (runtime.Unstructured, error, error) {
 	p.Log.Info("Hello from Build RestorePlugin!")
 
@@ -55,20 +55,8 @@ func (p *RestorePlugin) Execute(item runtime.Unstructured, restore *v1.Restore) 
 	return item, nil, nil
 }
 
-func (p *RestorePlugin) coreClient() (*corev1.CoreV1Client, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-	client, err := corev1.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	return client, nil
-}
-
 func (p *RestorePlugin) findBuilderDockercfgSecret(namespace string) string {
-	client, err := p.coreClient()
+	client, err := clients.NewCoreClient()
 	if err != nil {
 		return ""
 	}

--- a/velero-plugins/buildconfig/backup.go
+++ b/velero-plugins/buildconfig/backup.go
@@ -4,12 +4,10 @@ import (
 	"github.com/sirupsen/logrus"
 
 	//buildv1API "github.com/openshift/api/build/v1"
-	buildv1 "github.com/openshift/client-go/build/clientset/versioned/typed/build/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 
 	//metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
 
 	v1 "github.com/heptio/velero/pkg/apis/velero/v1"
 	"github.com/heptio/velero/pkg/backup"
@@ -43,23 +41,11 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 
 	annotations["openshift.io/buildconfig-plugin"] = "1"
 
-	/*client, err := p.buildClient()
+	/*client, err := clients.NewBuildClient()
 	if err != nil {
 		return nil, nil, err
 	}*/
 	metadata.SetAnnotations(annotations)
 
 	return item, nil, nil
-}
-
-func (p *BackupPlugin) buildClient() (*buildv1.BuildV1Client, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-	client, err := buildv1.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	return client, nil
 }

--- a/velero-plugins/clients/clients.go
+++ b/velero-plugins/clients/clients.go
@@ -1,0 +1,75 @@
+package clients
+
+import (
+	buildv1 "github.com/openshift/client-go/build/clientset/versioned/typed/build/v1"
+	imagev1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	routev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+	"k8s.io/client-go/discovery"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+)
+
+// NewCoreClient returns a kubernetes CoreV1Client
+func NewCoreClient() (*corev1.CoreV1Client, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err := corev1.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+// NewImageClient returns an openshift ImageV1Client
+func NewImageClient() (*imagev1.ImageV1Client, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err := imagev1.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+// NewDiscoveryClient returns a client-go DiscoveryClient
+func NewDiscoveryClient() (*discovery.DiscoveryClient, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+// NewRouteClient returns an openshift RouteV1Client
+func NewRouteClient() (*routev1.RouteV1Client, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err := routev1.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+// NewBuildClient returns an openshift BuildV1Client
+func NewBuildClient() (*buildv1.BuildV1Client, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err := buildv1.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}

--- a/velero-plugins/common/backup.go
+++ b/velero-plugins/common/backup.go
@@ -4,15 +4,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/rest"
 
+	"github.com/fusor/ocp-velero-plugin/velero-plugins/clients"
 	v1 "github.com/heptio/velero/pkg/apis/velero/v1"
 	"github.com/heptio/velero/pkg/backup"
+	"github.com/sirupsen/logrus"
 )
 
 // BackupPlugin is a backup item action plugin for Heptio Ark.
@@ -39,7 +37,7 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 		annotations = make(map[string]string)
 	}
 
-	client, err := p.discoveryClient()
+	client, err := clients.NewDiscoveryClient()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -51,21 +49,13 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 		version.Minor = strings.TrimSuffix(version.Minor, "+")
 	}
 
-	annotations["openshift.io/backup-server-version"] = fmt.Sprintf("%v.%v", version.Major, version.Minor)
-
+	annotations[BackupServerVersion] = fmt.Sprintf("%v.%v", version.Major, version.Minor)
+	registryHostname, err := getRegistryInfo(version.Major, version.Minor)
+	if err != nil {
+		return nil, nil, err
+	}
+	annotations[BackupRegistryHostname] = registryHostname
 	metadata.SetAnnotations(annotations)
 
 	return item, nil, nil
-}
-
-func (p *BackupPlugin) discoveryClient() (*discovery.DiscoveryClient, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-	client, err := discovery.NewDiscoveryClientForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	return client, nil
 }

--- a/velero-plugins/common/shared.go
+++ b/velero-plugins/common/shared.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/fusor/ocp-velero-plugin/velero-plugins/clients"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func getRegistryInfo(major, minor string) (string, error) {
+	if major != "1" {
+		return "", fmt.Errorf("server version %v.%v not supported. Must be 1.x", major, minor)
+	}
+	intVersion, err := strconv.Atoi(minor)
+	if err != nil {
+		return "", fmt.Errorf("server minor version %v invalid value: %v", minor, err)
+	}
+
+	cClient, err := clients.NewCoreClient()
+	if err != nil {
+		return "", err
+	}
+	if intVersion < 7 {
+		return "", fmt.Errorf("Kubernetes version 1.%v not supported. Must be 1.7 or greater", minor)
+	} else if intVersion <= 11 {
+		registrySvc, err := cClient.Services("default").Get("docker-registry", metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+		internalRegistry := registrySvc.Spec.ClusterIP + ":" + strconv.Itoa(int(registrySvc.Spec.Ports[0].Port))
+		return internalRegistry, nil
+	} else {
+		config, err := cClient.ConfigMaps("openshift-apiserver").Get("config", metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+		serverConfig := APIServerConfig{}
+		err = json.Unmarshal([]byte(config.Data["config.yaml"]), &serverConfig)
+		if err != nil {
+			return "", err
+		}
+		internalRegistry := serverConfig.ImagePolicyConfig.InternalRegistryHostname
+		if len(internalRegistry) == 0 {
+			return "", errors.New("InternalRegistryHostname not found")
+		}
+		return internalRegistry, nil
+	}
+}

--- a/velero-plugins/common/types.go
+++ b/velero-plugins/common/types.go
@@ -1,0 +1,23 @@
+package common
+
+type routingConfig struct {
+	Subdomain string `json:"subdomain"`
+}
+
+type imagePolicyConfig struct {
+	InternalRegistryHostname string `json:"internalRegistryHostname"`
+}
+
+// APIServerConfig stores configuration information about the current cluster
+type APIServerConfig struct {
+	ImagePolicyConfig imagePolicyConfig `json:"imagePolicyConfig"`
+	RoutingConfig     routingConfig     `json:"routingConfig"`
+}
+
+const BackupServerVersion string = "openshift.io/backup-server-version"
+const RestoreServerVersion string = "openshift.io/restore-server-version"
+
+const BackupRegistryHostname string = "openshift.io/backup-registry-hostname"
+const RestoreRegistryHostname string = "openshift.io/restore-registry-hostname"
+
+const MigrationRegistry string = "openshift.io/migration-registry"

--- a/velero-plugins/imagestream/shared.go
+++ b/velero-plugins/imagestream/shared.go
@@ -1,0 +1,65 @@
+package imagestream
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containers/image/copy"
+	"github.com/containers/image/signature"
+	"github.com/containers/image/transports/alltransports"
+	"github.com/containers/image/types"
+
+	"k8s.io/client-go/rest"
+)
+
+func copyImage(src, dest string, sourceCtx, destinationCtx *types.SystemContext) (string, error) {
+	policyContext, err := getPolicyContext()
+	if err != nil {
+		return "", fmt.Errorf("Error loading trust policy: %v", err)
+	}
+	defer policyContext.Destroy()
+
+	srcRef, err := alltransports.ParseImageName(src)
+	if err != nil {
+		return "", fmt.Errorf("Invalid source name %s: %v", src, err)
+	}
+	destRef, err := alltransports.ParseImageName(dest)
+	if err != nil {
+		return "", fmt.Errorf("Invalid destination name %s: %v", dest, err)
+	}
+	manifest, err := copy.Image(context.Background(), policyContext, destRef, srcRef, &copy.Options{
+		SourceCtx:      sourceCtx,
+		DestinationCtx: destinationCtx,
+	})
+	return string(manifest), err
+}
+
+func getPolicyContext() (*signature.PolicyContext, error) {
+	policy := &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
+	return signature.NewPolicyContext(policy)
+}
+
+func internalRegistrySystemContext() (*types.SystemContext, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := &types.SystemContext{
+		DockerDaemonInsecureSkipTLSVerify: true,
+		DockerInsecureSkipTLSVerify:       types.OptionalBoolTrue,
+		DockerAuthConfig: &types.DockerAuthConfig{
+			Username: "ignored",
+			Password: config.BearerToken,
+		},
+	}
+	return ctx, nil
+}
+
+func migrationRegistrySystemContext() (*types.SystemContext, error) {
+	ctx := &types.SystemContext{
+		DockerDaemonInsecureSkipTLSVerify: true,
+		DockerInsecureSkipTLSVerify:       types.OptionalBoolTrue,
+	}
+	return ctx, nil
+}

--- a/velero-plugins/route/backup.go
+++ b/velero-plugins/route/backup.go
@@ -4,12 +4,10 @@ import (
 	"github.com/sirupsen/logrus"
 
 	//routev1API "github.com/openshift/api/build/v1"
-	routev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 
 	//metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
 
 	v1 "github.com/heptio/velero/pkg/apis/velero/v1"
 	"github.com/heptio/velero/pkg/backup"
@@ -43,23 +41,11 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 
 	annotations["openshift.io/route-plugin"] = "1"
 
-	/*client, err := p.routeClient()
+	/*client, err := clients.NewRouteClient()
 	if err != nil {
 		return nil, nil, err
 	}*/
 	metadata.SetAnnotations(annotations)
 
 	return item, nil, nil
-}
-
-func (p *BackupPlugin) routeClient() (*routev1.RouteV1Client, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-	client, err := routev1.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	return client, nil
 }


### PR DESCRIPTION
Moves functions that are needed by both restore and backup actions
for a plugin into shared.go, in the same package as backup/restore.

Also, moves functions that are needed by multiple plugins into the
common package, except for the clients (CoreClient, ImageClient,
etc), which are moved into the clients package.

The latter part of this should resolve
https://github.com/fusor/ocp-velero-plugin/issues/8