### PR TITLE
remove symlinks in vendor that should have been pruned by dep

### DIFF
--- a/vendor/github.com/containers/image/copy/fixtures/Hello.bz2
+++ b/vendor/github.com/containers/image/copy/fixtures/Hello.bz2
@@ -1,1 +1,0 @@
-../../pkg/compression/fixtures/Hello.bz2

--- a/vendor/github.com/containers/image/copy/fixtures/Hello.gz
+++ b/vendor/github.com/containers/image/copy/fixtures/Hello.gz
@@ -1,1 +1,0 @@
-../../pkg/compression/fixtures/Hello.gz

--- a/vendor/github.com/containers/image/copy/fixtures/Hello.uncompressed
+++ b/vendor/github.com/containers/image/copy/fixtures/Hello.uncompressed
@@ -1,1 +1,0 @@
-../../pkg/compression/fixtures/Hello.uncompressed

--- a/vendor/github.com/containers/image/copy/fixtures/Hello.xz
+++ b/vendor/github.com/containers/image/copy/fixtures/Hello.xz
@@ -1,1 +1,0 @@
-../../pkg/compression/fixtures/Hello.xz

--- a/vendor/github.com/containers/image/manifest/fixtures/schema2-to-schema1-by-docker.json
+++ b/vendor/github.com/containers/image/manifest/fixtures/schema2-to-schema1-by-docker.json
@@ -1,1 +1,0 @@
-../../image/fixtures/schema2-to-schema1-by-docker.json

--- a/vendor/github.com/containers/image/pkg/tlsclientconfig/testdata/missing-cert/client-cert-1.key
+++ b/vendor/github.com/containers/image/pkg/tlsclientconfig/testdata/missing-cert/client-cert-1.key
@@ -1,1 +1,0 @@
-../full/client-cert-1.key

--- a/vendor/github.com/containers/image/pkg/tlsclientconfig/testdata/missing-key/client-cert-1.cert
+++ b/vendor/github.com/containers/image/pkg/tlsclientconfig/testdata/missing-key/client-cert-1.cert
@@ -1,1 +1,0 @@
-../full/client-cert-1.cert

--- a/vendor/github.com/containers/image/pkg/tlsclientconfig/testdata/unreadable-ca/unreadable.crt
+++ b/vendor/github.com/containers/image/pkg/tlsclientconfig/testdata/unreadable-ca/unreadable.crt
@@ -1,1 +1,0 @@
-/this/does/not/exist

--- a/vendor/github.com/containers/image/pkg/tlsclientconfig/testdata/unreadable-cert/client-cert-1.cert
+++ b/vendor/github.com/containers/image/pkg/tlsclientconfig/testdata/unreadable-cert/client-cert-1.cert
@@ -1,1 +1,0 @@
-/this/does/not/exist

--- a/vendor/github.com/containers/image/pkg/tlsclientconfig/testdata/unreadable-cert/client-cert-1.key
+++ b/vendor/github.com/containers/image/pkg/tlsclientconfig/testdata/unreadable-cert/client-cert-1.key
@@ -1,1 +1,0 @@
-../full/client-cert-1.key

--- a/vendor/github.com/containers/image/pkg/tlsclientconfig/testdata/unreadable-key/client-cert-1.cert
+++ b/vendor/github.com/containers/image/pkg/tlsclientconfig/testdata/unreadable-key/client-cert-1.cert
@@ -1,1 +1,0 @@
-../full/client-cert-1.cert

--- a/vendor/github.com/containers/image/pkg/tlsclientconfig/testdata/unreadable-key/client-cert-1.key
+++ b/vendor/github.com/containers/image/pkg/tlsclientconfig/testdata/unreadable-key/client-cert-1.key
@@ -1,1 +1,0 @@
-/this/does/not/exist

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-manifest-digest-error/manifest.json
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-manifest-digest-error/manifest.json
@@ -1,1 +1,0 @@
-../v2s1-invalid-signatures.manifest.json

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-manifest-digest-error/signature-1
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-manifest-digest-error/signature-1
@@ -1,1 +1,0 @@
-../dir-img-valid/signature-1

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-mixed/manifest.json
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-mixed/manifest.json
@@ -1,1 +1,0 @@
-../dir-img-valid/manifest.json

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-mixed/signature-1
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-mixed/signature-1
@@ -1,1 +1,0 @@
-../invalid-blob.signature

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-mixed/signature-2
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-mixed/signature-2
@@ -1,1 +1,0 @@
-../dir-img-valid/signature-1

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-modified-manifest/signature-1
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-modified-manifest/signature-1
@@ -1,1 +1,0 @@
-../dir-img-valid/signature-1

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-no-manifest/signature-1
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-no-manifest/signature-1
@@ -1,1 +1,0 @@
-../dir-img-valid/signature-1

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-unsigned/manifest.json
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-unsigned/manifest.json
@@ -1,1 +1,0 @@
-../dir-img-valid/manifest.json

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-valid-2/manifest.json
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-valid-2/manifest.json
@@ -1,1 +1,0 @@
-../dir-img-valid/manifest.json

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-valid-2/signature-1
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-valid-2/signature-1
@@ -1,1 +1,0 @@
-../dir-img-valid/signature-1

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-valid/manifest.json
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-valid/manifest.json
@@ -1,1 +1,0 @@
-../image.manifest.json

--- a/vendor/github.com/docker/docker/integration-cli/fixtures/https/ca.pem
+++ b/vendor/github.com/docker/docker/integration-cli/fixtures/https/ca.pem
@@ -1,1 +1,0 @@
-../../../integration/testdata/https/ca.pem

--- a/vendor/github.com/docker/docker/integration-cli/fixtures/https/client-cert.pem
+++ b/vendor/github.com/docker/docker/integration-cli/fixtures/https/client-cert.pem
@@ -1,1 +1,0 @@
-../../../integration/testdata/https/client-cert.pem

--- a/vendor/github.com/docker/docker/integration-cli/fixtures/https/client-key.pem
+++ b/vendor/github.com/docker/docker/integration-cli/fixtures/https/client-key.pem
@@ -1,1 +1,0 @@
-../../../integration/testdata/https/client-key.pem

--- a/vendor/github.com/docker/docker/integration-cli/fixtures/https/server-cert.pem
+++ b/vendor/github.com/docker/docker/integration-cli/fixtures/https/server-cert.pem
@@ -1,1 +1,0 @@
-../../../integration/testdata/https/server-cert.pem

--- a/vendor/github.com/docker/docker/integration-cli/fixtures/https/server-key.pem
+++ b/vendor/github.com/docker/docker/integration-cli/fixtures/https/server-key.pem
@@ -1,1 +1,0 @@
-../../../integration/testdata/https/server-key.pem

--- a/vendor/github.com/docker/docker/project/CONTRIBUTING.md
+++ b/vendor/github.com/docker/docker/project/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-../CONTRIBUTING.md


### PR DESCRIPTION
When dep prunes non-go code, it misses symlinks to test fixtures
(and other similar cases of symlinks to other files that were
pruned).

For future commits to vendor/, if 'find -L vendor/ -type l' returns
any symlinks, make sure they're not pointing to anything real, and
remove them. If they happen to point to actual go files (or other files
needed), then copying them probably makes more sense.