### PR TITLE
Velero dependency changes needed for SkipRestore

### DIFF
--- a/vendor/github.com/heptio/velero/pkg/plugin/generated/RestoreItemAction.pb.go
+++ b/vendor/github.com/heptio/velero/pkg/plugin/generated/RestoreItemAction.pb.go
@@ -58,8 +58,9 @@ func (m *RestoreExecuteRequest) GetItemFromBackup() []byte {
 }
 
 type RestoreExecuteResponse struct {
-	Item    []byte `protobuf:"bytes,1,opt,name=item,proto3" json:"item,omitempty"`
-	Warning string `protobuf:"bytes,2,opt,name=warning" json:"warning,omitempty"`
+	Item        []byte `protobuf:"bytes,1,opt,name=item,proto3" json:"item,omitempty"`
+	Warning     string `protobuf:"bytes,2,opt,name=warning" json:"warning,omitempty"`
+	SkipRestore bool   `protobuf:"varint,3,opt,name=skipRestore,proto3" json:"skipRestore,omitempty"`
 }
 
 func (m *RestoreExecuteResponse) Reset()                    { *m = RestoreExecuteResponse{} }
@@ -79,6 +80,13 @@ func (m *RestoreExecuteResponse) GetWarning() string {
 		return m.Warning
 	}
 	return ""
+}
+
+func (m *RestoreExecuteResponse) GetSkipRestore() bool {
+	if m != nil {
+		return m.SkipRestore
+	}
+	return false
 }
 
 func init() {

--- a/vendor/github.com/heptio/velero/pkg/plugin/restore_item_action.go
+++ b/vendor/github.com/heptio/velero/pkg/plugin/restore_item_action.go
@@ -126,6 +126,7 @@ func (c *RestoreItemActionGRPCClient) Execute(input *velero.RestoreItemActionExe
 	return &velero.RestoreItemActionExecuteOutput{
 		UpdatedItem: &updatedItem,
 		Warning:     warning,
+		SkipRestore: res.SkipRestore,
 	}, nil
 }
 
@@ -235,7 +236,8 @@ func (s *RestoreItemActionGRPCServer) Execute(ctx context.Context, req *proto.Re
 	}
 
 	return &proto.RestoreExecuteResponse{
-		Item:    updatedItem,
-		Warning: warnMessage,
+		Item:        updatedItem,
+		Warning:     warnMessage,
+		SkipRestore: executeOutput.SkipRestore,
 	}, nil
 }

--- a/vendor/github.com/heptio/velero/pkg/plugin/velero/restore_item_action.go
+++ b/vendor/github.com/heptio/velero/pkg/plugin/velero/restore_item_action.go
@@ -55,6 +55,9 @@ type RestoreItemActionExecuteOutput struct {
 	// Warning is an exceptional message returned from ItemAction
 	// which is not preventing the item from being restored.
 	Warning error
+	// SkipRestore tells velero to stop executing further actions
+	// on this item, and skip the restore step.
+	SkipRestore bool
 }
 
 // NewRestoreItemActionExecuteOutput creates a new RestoreItemActionExecuteOutput
@@ -67,5 +70,10 @@ func NewRestoreItemActionExecuteOutput(item runtime.Unstructured) *RestoreItemAc
 // WithWarning returns a warning for RestoreItemActionExecuteOutput
 func (r *RestoreItemActionExecuteOutput) WithWarning(err error) *RestoreItemActionExecuteOutput {
 	r.Warning = err
+	return r
+}
+// WithoutRestore returns SkipRestore for RestoreItemActionExecuteOutput
+func (r *RestoreItemActionExecuteOutput) WithoutRestore() *RestoreItemActionExecuteOutput {
+	r.SkipRestore = true
 	return r
 }


### PR DESCRIPTION
These are the velero files needed by the plugin that were changed with
https://github.com/fusor/velero/pull/10

They're manually copied over for now, but I can re-run dep after the
velero fork PR is merged to see if anything changes from here.