### PR TITLE
Imagestream restore plugin

### DIFF
--- a/velero-plugins/imagestream/restore.go
+++ b/velero-plugins/imagestream/restore.go
@@ -1,9 +1,15 @@
 package imagestream
 
 import (
-	"github.com/heptio/velero/pkg/plugin/velero"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/fusor/ocp-velero-plugin/velero-plugins/common"
+        "github.com/heptio/velero/pkg/plugin/velero"
+	imagev1API "github.com/openshift/api/image/v1"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/api/meta"
 )
 
 // MyRestorePlugin is a restore item action plugin for Velero
@@ -18,22 +24,86 @@ func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 	}, nil
 }
 
+// Execute copies local registry images from migration registry into target cluster local registry
 func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
 	p.Log.Info("Hello from ImageStream RestorePlugin!")
 
-	metadata, err := meta.Accessor(input.Item)
-	if err != nil {
-		return nil, err
-	}
-
-	annotations := metadata.GetAnnotations()
+	imageStream := imagev1API.ImageStream{}
+	itemMarshal, _ := json.Marshal(input.Item)
+	json.Unmarshal(itemMarshal, &imageStream)
+	p.Log.Info(fmt.Sprintf("image: %#v", imageStream))
+	annotations := imageStream.Annotations
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
 
-	annotations["openshift.io/imagestream-restore-plugin"] = "1"
+	imageStreamUnmodified := imagev1API.ImageStream{}
+	itemMarshal, _ = json.Marshal(input.ItemFromBackup)
+	json.Unmarshal(itemMarshal, &imageStreamUnmodified)
 
-	metadata.SetAnnotations(annotations)
+	internalRegistry := annotations[common.RestoreRegistryHostname]
+	if len(internalRegistry) == 0 {
+		return nil, errors.New("restore cluster registry not found for annotation \"openshift.io/restore-registry-hostname\"")
+	}
+	backupInternalRegistry := annotations[common.BackupRegistryHostname]
+	if len(internalRegistry) == 0 {
+		return nil, errors.New("backup cluster registry not found for annotation \"openshift.io/backup-registry-hostname\"")
+	}
+	migrationRegistry := input.Restore.Annotations[common.MigrationRegistry]
+	if len(migrationRegistry) == 0 {
+		return nil, errors.New("migration registry not found for annotation \"openshift.io/migration\"")
+	}
+	p.Log.Info(fmt.Sprintf("backup internal registry: %#v", backupInternalRegistry))
+	p.Log.Info(fmt.Sprintf("restore internal registry: %#v", internalRegistry))
 
-	return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+	for _, tag := range imageStreamUnmodified.Status.Tags {
+		p.Log.Info(fmt.Sprintf("Restoring tag: %#v", tag.Tag))
+		specTag := findSpecTag(imageStreamUnmodified.Spec.Tags, tag.Tag)
+		copyToTag := true
+		if specTag != nil && specTag.From != nil {
+			p.Log.Info(fmt.Sprintf("image tagged: %s, %s", specTag.From.Kind, specTag.From.Name))
+			// we have a tag.
+			copyToTag = false
+		}
+		// Iterate over items in reverse order so most recently tagged is copied last
+		for i := len(tag.Items) - 1; i >= 0; i-- {
+			dockerImageReference := tag.Items[i].DockerImageReference
+			if strings.HasPrefix(dockerImageReference, backupInternalRegistry) {
+				destTag := "@" + tag.Items[i].Image
+				if copyToTag {
+					destTag = ":" + tag.Tag
+				}
+				srcPath := fmt.Sprintf("docker://%s/%s/%s@%s", migrationRegistry, imageStreamUnmodified.Namespace, imageStreamUnmodified.Name, tag.Items[i].Image)
+				destPath := fmt.Sprintf("docker://%s/%s/%s%s", internalRegistry, imageStreamUnmodified.Namespace, imageStreamUnmodified.Name, destTag)
+
+				p.Log.Info(fmt.Sprintf("copying from: %s", srcPath))
+				p.Log.Info(fmt.Sprintf("copying to: %s", destPath))
+				manifest, err := copyImageRestore(srcPath, destPath)
+				if err != nil {
+					return nil, err
+				}
+				p.Log.Info(fmt.Sprintf("manifest of copied image: %s", manifest))
+			}
+		}
+	}
+
+	imageStream.Annotations = annotations
+	var out map[string]interface{}
+	objrec, _ := json.Marshal(imageStream)
+	json.Unmarshal(objrec, &out)
+	input.Item.SetUnstructuredContent(out)
+
+	return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
+}
+
+func copyImageRestore(src, dest string) (string, error) {
+	sourceCtx, err := migrationRegistrySystemContext()
+	if err != nil {
+		return "", err
+	}
+	destinationCtx, err := internalRegistrySystemContext()
+	if err != nil {
+		return "", err
+	}
+	return copyImage(src, dest, sourceCtx, destinationCtx)
 }

--- a/velero-plugins/imagestream/shared.go
+++ b/velero-plugins/imagestream/shared.go
@@ -2,12 +2,14 @@ package imagestream
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/containers/image/copy"
 	"github.com/containers/image/signature"
 	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/image/types"
+	imagev1API "github.com/openshift/api/image/v1"
 
 	"k8s.io/client-go/rest"
 )
@@ -44,7 +46,9 @@ func internalRegistrySystemContext() (*types.SystemContext, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	if config.BearerToken == "" {
+		return nil, errors.New("BearerToken not found, can't authenticate with registry")
+	}
 	ctx := &types.SystemContext{
 		DockerDaemonInsecureSkipTLSVerify: true,
 		DockerInsecureSkipTLSVerify:       types.OptionalBoolTrue,
@@ -62,4 +66,13 @@ func migrationRegistrySystemContext() (*types.SystemContext, error) {
 		DockerInsecureSkipTLSVerify:       types.OptionalBoolTrue,
 	}
 	return ctx, nil
+}
+
+func findSpecTag(tags []imagev1API.TagReference, name string) *imagev1API.TagReference {
+	for _, tag := range tags {
+		if tag.Name == name {
+			return &tag
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Copies image from migration registry for local images.
Discards item on restore, since:
1) for local images, image import recreates imagestream
2) for remote images, imagestreamtag restore recreates imagestream