### PR TITLE
Fix plugin tests which selectively apply plugin actions for migrations

### DIFF
--- a/velero-plugins/common/backup.go
+++ b/velero-plugins/common/backup.go
@@ -29,18 +29,20 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 		return nil, nil, err
 	}
 
-	version, err := GetServerVersion()
-	if err != nil {
-		return nil, nil, err
-	}
+	if backup.Annotations[MigrateCopyPhaseAnnotation] != "" {
+		version, err := GetServerVersion()
+		if err != nil {
+			return nil, nil, err
+		}
 
-	annotations[BackupServerVersion] = fmt.Sprintf("%v.%v", version.Major, version.Minor)
-	registryHostname, err := GetRegistryInfo(version.Major, version.Minor)
-	if err != nil {
-		return nil, nil, err
+		annotations[BackupServerVersion] = fmt.Sprintf("%v.%v", version.Major, version.Minor)
+		registryHostname, err := GetRegistryInfo(version.Major, version.Minor)
+		if err != nil {
+			return nil, nil, err
+		}
+		annotations[BackupRegistryHostname] = registryHostname
+		metadata.SetAnnotations(annotations)
 	}
-	annotations[BackupRegistryHostname] = registryHostname
-	metadata.SetAnnotations(annotations)
 
 	return item, nil, nil
 }

--- a/velero-plugins/common/restore.go
+++ b/velero-plugins/common/restore.go
@@ -28,8 +28,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	name := metadata.GetName()
 	p.Log.Infof("common restore plugin for %s", name)
 
-	if input.Restore.Annotations[MigrateTypeAnnotation] == "swing" ||
-		input.Restore.Annotations[MigrateCopyPhaseAnnotation] == "final" {
+	if input.Restore.Annotations[MigrateCopyPhaseAnnotation] != "" {
 
 		version, err := GetServerVersion()
 		if err != nil {

--- a/velero-plugins/daemonset/restore.go
+++ b/velero-plugins/daemonset/restore.go
@@ -31,8 +31,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	json.Unmarshal(itemMarshal, &daemonSet)
 	p.Log.Infof("[daemonset-restore] daemonset: %s", daemonSet.Name)
 
-	if input.Restore.Annotations[common.MigrateTypeAnnotation] == "swing" ||
-		input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] == "final" {
+	if input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] != "" {
 
 		backupRegistry, registry, err := common.GetSrcAndDestRegistryInfo(input.Item)
 		if err != nil {

--- a/velero-plugins/deployment/restore.go
+++ b/velero-plugins/deployment/restore.go
@@ -31,8 +31,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	json.Unmarshal(itemMarshal, &deployment)
 	p.Log.Infof("[deployment-restore] deployment: %s", deployment.Name)
 
-	if input.Restore.Annotations[common.MigrateTypeAnnotation] == "swing" ||
-		input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] == "final" {
+	if input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] != "" {
 
 		backupRegistry, registry, err := common.GetSrcAndDestRegistryInfo(input.Item)
 		if err != nil {

--- a/velero-plugins/deploymentconfig/restore.go
+++ b/velero-plugins/deploymentconfig/restore.go
@@ -31,8 +31,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	json.Unmarshal(itemMarshal, &deploymentConfig)
 	p.Log.Infof("[deploymentconfig-restore] deploymentConfig: %s", deploymentConfig.Name)
 
-	if input.Restore.Annotations[common.MigrateTypeAnnotation] == "swing" ||
-		input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] == "final" {
+	if input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] != "" {
 
 		backupRegistry, registry, err := common.GetSrcAndDestRegistryInfo(input.Item)
 		if err != nil {

--- a/velero-plugins/imagestream/backup.go
+++ b/velero-plugins/imagestream/backup.go
@@ -41,7 +41,7 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 		annotations = make(map[string]string)
 	}
 
-	if backup.Annotations[common.MigrateTypeAnnotation] != "" {
+	if backup.Annotations[common.MigrateCopyPhaseAnnotation] != "" {
 		internalRegistry := annotations[common.BackupRegistryHostname]
 		if len(internalRegistry) == 0 {
 			return nil, nil, errors.New("backup cluster registry not found for annotation \"openshift.io/backup-registry-hostname\"")

--- a/velero-plugins/imagestream/restore.go
+++ b/velero-plugins/imagestream/restore.go
@@ -37,7 +37,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		annotations = make(map[string]string)
 	}
 
-	if input.Restore.Annotations[common.MigrateTypeAnnotation] != "" {
+	if input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] != "" {
 		imageStreamUnmodified := imagev1API.ImageStream{}
 		itemMarshal, _ = json.Marshal(input.ItemFromBackup)
 		json.Unmarshal(itemMarshal, &imageStreamUnmodified)

--- a/velero-plugins/imagestreamtag/restore.go
+++ b/velero-plugins/imagestreamtag/restore.go
@@ -31,7 +31,7 @@ func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
 	p.Log.Info("[istag-restore] Hello from ImageStreamTag RestorePlugin!")
 
-	if input.Restore.Annotations[common.MigrateTypeAnnotation] != "" {
+	if input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] != "" {
 		imageStreamTag := imagev1API.ImageStreamTag{}
 		itemMarshal, _ := json.Marshal(input.Item)
 		json.Unmarshal(itemMarshal, &imageStreamTag)

--- a/velero-plugins/job/restore.go
+++ b/velero-plugins/job/restore.go
@@ -31,8 +31,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	json.Unmarshal(itemMarshal, &job)
 	p.Log.Infof("[job-restore] job: %s", job.Name)
 
-	if input.Restore.Annotations[common.MigrateTypeAnnotation] == "swing" ||
-		input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] == "final" {
+	if input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] != "" {
 
 		backupRegistry, registry, err := common.GetSrcAndDestRegistryInfo(input.Item)
 		if err != nil {

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -35,8 +35,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	if input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] == "stage" {
 		common.ConfigureContainerSleep(pod.Spec.Containers, "infinity")
 		common.ConfigureContainerSleep(pod.Spec.InitContainers, "0")
-	} else if input.Restore.Annotations[common.MigrateTypeAnnotation] == "swing" ||
-		input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] == "final" {
+	} else if input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] != "" {
 
 		registry := pod.Annotations[common.RestoreRegistryHostname]
 		backupRegistry := pod.Annotations[common.BackupRegistryHostname]

--- a/velero-plugins/replicaset/restore.go
+++ b/velero-plugins/replicaset/restore.go
@@ -31,8 +31,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	json.Unmarshal(itemMarshal, &replicaSet)
 	p.Log.Infof("[replicaset-restore] replicaset: %s", replicaSet.Name)
 
-	if input.Restore.Annotations[common.MigrateTypeAnnotation] == "swing" ||
-		input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] == "final" {
+	if input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] != "" {
 
 		backupRegistry, registry, err := common.GetSrcAndDestRegistryInfo(input.Item)
 		if err != nil {

--- a/velero-plugins/replicationcontroller/restore.go
+++ b/velero-plugins/replicationcontroller/restore.go
@@ -31,8 +31,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	json.Unmarshal(itemMarshal, &replicationController)
 	p.Log.Infof("[replicationcontroller-restore] replicationController: %s", replicationController.Name)
 
-	if input.Restore.Annotations[common.MigrateTypeAnnotation] == "swing" ||
-		input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] == "final" {
+	if input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] != "" {
 
 		backupRegistry, registry, err := common.GetSrcAndDestRegistryInfo(input.Item)
 		if err != nil {

--- a/velero-plugins/statefulset/restore.go
+++ b/velero-plugins/statefulset/restore.go
@@ -31,8 +31,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	json.Unmarshal(itemMarshal, &statefulSet)
 	p.Log.Infof("[statefulset-restore] statefulset: %s", statefulSet.Name)
 
-	if input.Restore.Annotations[common.MigrateTypeAnnotation] == "swing" ||
-		input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] == "final" {
+	if input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] != "" {
 
 		backupRegistry, registry, err := common.GetSrcAndDestRegistryInfo(input.Item)
 		if err != nil {


### PR DESCRIPTION
We have a number of checks to selectively apply plugin logic. Most
actions are only carried out if we're in the context of a controller
stage or migration action. The anticipated use of stage/migration
annotations has changed since this was originally added to the plugin.
This commit fixes this to work with the current controller code.