### PR TITLE
Remove skipping of restore if pod has owner references

### DIFF
--- a/velero-plugins/common/types.go
+++ b/velero-plugins/common/types.go
@@ -33,3 +33,7 @@ const MigrateCopyPhaseAnnotation string = "openshift.io/migrate-copy-phase"
 const MigrateQuiesceAnnotation string = "openshift.io/migrate-quiesce-pods"
 
 const PodStageLabel string = "migration-stage-pod"
+
+// Restic annotations
+const ResticRestoreAnnotationPrefix string = "snapshot.velero.io"
+const ResticBackupAnnotation string = "backup.velero.io/backup-volumes"

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -51,7 +51,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 			return nil, err
 		}
 		// Check if pod has owner Refs and does not have restic backup associated with it
-		if len(ownerRefs) > 0 && pod.Annotations[common.ResticBackupAnnotation] != "" {
+		if len(ownerRefs) > 0 && pod.Annotations[common.ResticBackupAnnotation] == "" {
 			p.Log.Infof("[pod-restore] skipping restore of pod %s, has owner references and no restic backup", pod.Name)
 			return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
 		}

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -45,15 +45,6 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		}
 		common.SwapContainerImageRefs(pod.Spec.Containers, backupRegistry, registry, p.Log)
 		common.SwapContainerImageRefs(pod.Spec.InitContainers, backupRegistry, registry, p.Log)
-
-		ownerRefs, err := common.GetOwnerReferences(input.ItemFromBackup)
-		if err != nil {
-			return nil, err
-		}
-		if len(ownerRefs) > 0 {
-			p.Log.Infof("[pod-restore] skipping restore of pod %s, has owner references", pod.Name)
-			return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
-		}
 	}
 
 	var out map[string]interface{}


### PR DESCRIPTION
On restore, if a pod has a restic volume skipping restore of pods with ownerReferences breaks Restic completely. If there is a need to keep this code in then I will add a check for
```
if len(ownerRefs) > 0 && podHasResticAnnotation{
}
```