### PR TITLE
Fix dereference panic if trigger.ImageChangeBUild is nil

### DIFF
--- a/velero-plugins/build/restore.go
+++ b/velero-plugins/build/restore.go
@@ -86,7 +86,9 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	// if it is not sourceBuildStrategyType
 	build.Spec.Strategy.SourceStrategy.From.Name = newName
 	for _, trigger := range build.Spec.TriggeredBy {
-		trigger.ImageChangeBuild.ImageID = newName
+		if trigger.ImageChangeBuild != nil {
+			trigger.ImageChangeBuild.ImageID = newName
+		}
 	}
 
 	var out map[string]interface{}


### PR DESCRIPTION
We need to check for nil before trying to set trigger.ImageChangeBuild.ImageID
in the build restore plugin.