### PR TITLE
Fixing label selector and node selectors before restoring pod and pvcs

### DIFF
--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -32,6 +32,11 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	json.Unmarshal(itemMarshal, &pod)
 	p.Log.Infof("[pod-restore] pod: %s", pod.Name)
 
+	// ISSUE-61 : removing the node selectors from pods
+	// to avoid pod never getting `unscheduled` on destination
+	p.Log.Infof("[pod-restore] Pranav")
+	pod.Spec.NodeSelector = nil
+
 	if input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] == "stage" {
 		common.ConfigureContainerSleep(pod.Spec.Containers, "infinity")
 		common.ConfigureContainerSleep(pod.Spec.InitContainers, "0")

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -34,7 +34,6 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 
 	// ISSUE-61 : removing the node selectors from pods
 	// to avoid pod never getting `unscheduled` on destination
-	p.Log.Infof("[pod-restore] Pranav")
 	pod.Spec.NodeSelector = nil
 
 	if input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] == "stage" {

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -33,7 +33,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	p.Log.Infof("[pod-restore] pod: %s", pod.Name)
 
 	// ISSUE-61 : removing the node selectors from pods
-	// to avoid pod never getting `unscheduled` on destination
+	// to avoid pod being `unschedulable` on destination
 	pod.Spec.NodeSelector = nil
 
 	if input.Restore.Annotations[common.MigrateCopyPhaseAnnotation] == "stage" {

--- a/velero-plugins/pvc/restore.go
+++ b/velero-plugins/pvc/restore.go
@@ -40,7 +40,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		delete(pvc.Annotations, "pv.kubernetes.io/bound-by-controller")
 
 		// ISSUE-61 : removing the label selectors from PV's
-		// to avoid dynamically allocated PV's getting stuck
+		// to avoid PV dynamic provisioner getting stuck
 		pvc.Spec.Selector = nil
 	}
 

--- a/velero-plugins/pvc/restore.go
+++ b/velero-plugins/pvc/restore.go
@@ -39,7 +39,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		delete(pvc.Annotations, "pv.kubernetes.io/bind-completed")
 		delete(pvc.Annotations, "pv.kubernetes.io/bound-by-controller")
 
-		// ISSUE-61 : removing the label selectors from PV's
+		// ISSUE-61 : removing the label selectors from PVC's
 		// to avoid PV dynamic provisioner getting stuck
 		pvc.Spec.Selector = nil
 	}

--- a/velero-plugins/pvc/restore.go
+++ b/velero-plugins/pvc/restore.go
@@ -42,6 +42,8 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		// ISSUE-61 : removing the label selectors from PVC's
 		// to avoid PV dynamic provisioner getting stuck
 		pvc.Spec.Selector = nil
+		// ISSUE-61 : remove storage class name to fallback to default storage class
+		pvc.Spec.StorageClassName = nil
 	}
 
 	var out map[string]interface{}

--- a/velero-plugins/pvc/restore.go
+++ b/velero-plugins/pvc/restore.go
@@ -38,6 +38,10 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		pvc.Spec.VolumeName = ""
 		delete(pvc.Annotations, "pv.kubernetes.io/bind-completed")
 		delete(pvc.Annotations, "pv.kubernetes.io/bound-by-controller")
+
+		// ISSUE-61 : removing the label selectors from PV's
+		// to avoid dynamically allocated PV's getting stuck
+		pvc.Spec.Selector = nil
 	}
 
 	var out map[string]interface{}


### PR DESCRIPTION
removed node selector from restored pods, removed label selectors from restored pvcs (only for copy action)

Addresses #61 

Signed-off-by: Pranav Gaikwad <pgaikwad@redhat.com>